### PR TITLE
Items cruds

### DIFF
--- a/src/main/java/lk/icbt/pahana/dao/ItemDAO.java
+++ b/src/main/java/lk/icbt/pahana/dao/ItemDAO.java
@@ -1,0 +1,86 @@
+package lk.icbt.pahana.dao;
+
+import lk.icbt.pahana.model.Item;
+import java.sql.*;
+import java.util.*;
+import java.math.BigDecimal;
+
+public class ItemDAO {
+
+    public int create(Item it, String createdBy) throws SQLException {
+        String sql = "INSERT INTO items (name, unit_price, status, created_by) VALUES (?,?,?,?)";
+        try (Connection con = ConnectionFactory.getInstance().getConnection();
+             PreparedStatement ps = con.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setString(1, it.getName());
+            ps.setBigDecimal(2, it.getUnitPrice());
+            ps.setString(3, it.getStatus());
+            ps.setString(4, createdBy);
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                return rs.next() ? rs.getInt(1) : -1;
+            }
+        }
+    }
+
+    public void update(Item it, String updatedBy) throws SQLException {
+        String sql = "UPDATE items SET name=?, unit_price=?, status=?, updated_by=? WHERE id=?";
+        try (Connection con = ConnectionFactory.getInstance().getConnection();
+             PreparedStatement ps = con.prepareStatement(sql)) {
+            ps.setString(1, it.getName());
+            ps.setBigDecimal(2, it.getUnitPrice());
+            ps.setString(3, it.getStatus());
+            ps.setString(4, updatedBy);
+            ps.setInt(5, it.getId());
+            ps.executeUpdate();
+        }
+    }
+
+    public void deleteById(int id) throws SQLException {
+        String sql = "DELETE FROM items WHERE id=?";
+        try (Connection con = ConnectionFactory.getInstance().getConnection();
+             PreparedStatement ps = con.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        }
+    }
+
+    public Item findById(int id) throws SQLException {
+        String sql = "SELECT id,name,unit_price,status,created_at,created_by,updated_at,updated_by FROM items WHERE id=?";
+        try (Connection con = ConnectionFactory.getInstance().getConnection();
+             PreparedStatement ps = con.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? map(rs) : null;
+            }
+        }
+    }
+
+    public List<Item> findAll(String q) throws SQLException {
+        boolean hasQ = q != null && !q.trim().isEmpty();
+        String base = "SELECT id,name,unit_price,status,created_at,created_by,updated_at,updated_by FROM items ";
+        String sql = hasQ ? base + "WHERE name LIKE ? ORDER BY created_at DESC"
+                : base + "ORDER BY created_at DESC";
+        try (Connection con = ConnectionFactory.getInstance().getConnection();
+             PreparedStatement ps = con.prepareStatement(sql)) {
+            if (hasQ) ps.setString(1, "%" + q.trim() + "%");
+            try (ResultSet rs = ps.executeQuery()) {
+                List<Item> list = new ArrayList<>();
+                while (rs.next()) list.add(map(rs));
+                return list;
+            }
+        }
+    }
+
+    private Item map(ResultSet rs) throws SQLException {
+        Item it = new Item();
+        it.setId(rs.getInt("id"));
+        it.setName(rs.getString("name"));
+        it.setUnitPrice(rs.getBigDecimal("unit_price"));
+        it.setStatus(rs.getString("status"));
+        it.setCreatedAt(rs.getTimestamp("created_at"));
+        it.setCreatedBy(rs.getString("created_by"));
+        it.setUpdatedAt(rs.getTimestamp("updated_at"));
+        it.setUpdatedBy(rs.getString("updated_by"));
+        return it;
+    }
+}

--- a/src/main/java/lk/icbt/pahana/model/Item.java
+++ b/src/main/java/lk/icbt/pahana/model/Item.java
@@ -1,0 +1,32 @@
+package lk.icbt.pahana.model;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+
+public class Item {
+    private int id;
+    private String name;
+    private BigDecimal unitPrice;
+    private String status; // ACTIVE | INACTIVE
+    private Timestamp createdAt;
+    private String createdBy;
+    private Timestamp updatedAt;
+    private String updatedBy;
+
+    public int getId() { return id; }
+    public void setId(int id) { this.id = id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public BigDecimal getUnitPrice() { return unitPrice; }
+    public void setUnitPrice(BigDecimal unitPrice) { this.unitPrice = unitPrice; }
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+    public Timestamp getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Timestamp createdAt) { this.createdAt = createdAt; }
+    public String getCreatedBy() { return createdBy; }
+    public void setCreatedBy(String createdBy) { this.createdBy = createdBy; }
+    public Timestamp getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(Timestamp updatedAt) { this.updatedAt = updatedAt; }
+    public String getUpdatedBy() { return updatedBy; }
+    public void setUpdatedBy(String updatedBy) { this.updatedBy = updatedBy; }
+}

--- a/src/main/java/lk/icbt/pahana/service/ItemService.java
+++ b/src/main/java/lk/icbt/pahana/service/ItemService.java
@@ -1,0 +1,37 @@
+package lk.icbt.pahana.service;
+
+import lk.icbt.pahana.dao.ItemDAO;
+import lk.icbt.pahana.model.Item;
+
+import java.math.BigDecimal;
+import java.sql.SQLException;
+import java.util.List;
+
+public class ItemService {
+    private final ItemDAO dao = new ItemDAO();
+
+    public int create(Item it, String createdBy) throws Exception {
+        validateNew(it);
+        return dao.create(it, createdBy);
+    }
+
+    public void update(Item it, String updatedBy) throws Exception {
+        if (it.getId() <= 0) throw new Exception("Invalid item id.");
+        validateCommon(it);
+        dao.update(it, updatedBy);
+    }
+
+    public void deleteById(int id) throws SQLException { dao.deleteById(id); }
+    public Item find(int id) throws SQLException { return dao.findById(id); }
+    public List<Item> list(String q) throws SQLException { return dao.findAll(q); }
+
+    private void validateNew(Item it) throws Exception { validateCommon(it); }
+    private void validateCommon(Item it) throws Exception {
+        if (it.getName() == null || it.getName().trim().length() < 2)
+            throw new Exception("Item name must be at least 2 characters.");
+        if (it.getUnitPrice() == null || it.getUnitPrice().compareTo(BigDecimal.ZERO) < 0)
+            throw new Exception("Unit price cannot be negative.");
+        if (it.getStatus() == null || !(it.getStatus().equals("ACTIVE") || it.getStatus().equals("INACTIVE")))
+            throw new Exception("Status must be ACTIVE or INACTIVE.");
+    }
+}

--- a/src/main/java/lk/icbt/pahana/web/ItemCreateServlet.java
+++ b/src/main/java/lk/icbt/pahana/web/ItemCreateServlet.java
@@ -1,0 +1,33 @@
+package lk.icbt.pahana.web;
+
+import lk.icbt.pahana.model.Item;
+import lk.icbt.pahana.service.ItemService;
+
+import javax.servlet.http.*;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.math.BigDecimal;
+
+public class ItemCreateServlet extends HttpServlet {
+    private final ItemService service = new ItemService();
+
+    @Override protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        Item it = new Item();
+        it.setName(req.getParameter("name"));
+        it.setStatus(req.getParameter("status"));
+        try { it.setUnitPrice(new BigDecimal(req.getParameter("unit_price"))); }
+        catch (Exception e) { it.setUnitPrice(null); }
+
+        String createdBy = String.valueOf(req.getSession().getAttribute("username"));
+        try {
+            service.create(it, createdBy);
+            resp.sendRedirect(req.getContextPath()+"/items?msg=created");
+        } catch (Exception ex) {
+            req.setAttribute("mode", "create");
+            req.setAttribute("error", ex.getMessage());
+            req.setAttribute("item", it);
+            req.getRequestDispatcher("/views/item_form.jsp").forward(req, resp);
+        }
+    }
+}

--- a/src/main/java/lk/icbt/pahana/web/ItemDeleteServlet.java
+++ b/src/main/java/lk/icbt/pahana/web/ItemDeleteServlet.java
@@ -1,0 +1,21 @@
+package lk.icbt.pahana.web;
+
+import lk.icbt.pahana.service.ItemService;
+
+import javax.servlet.http.*;
+import javax.servlet.ServletException;
+import java.io.IOException;
+
+public class ItemDeleteServlet extends HttpServlet {
+    private final ItemService service = new ItemService();
+    @Override protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        try {
+            int id = Integer.parseInt(req.getParameter("id"));
+            service.deleteById(id);
+            resp.sendRedirect(req.getContextPath()+"/items?msg=deleted");
+        } catch (Exception e) {
+            resp.sendRedirect(req.getContextPath()+"/items?err=bad_id");
+        }
+    }
+}

--- a/src/main/java/lk/icbt/pahana/web/ItemEditServlet.java
+++ b/src/main/java/lk/icbt/pahana/web/ItemEditServlet.java
@@ -1,0 +1,46 @@
+package lk.icbt.pahana.web;
+
+import lk.icbt.pahana.model.Item;
+import lk.icbt.pahana.service.ItemService;
+
+import javax.servlet.http.*;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.math.BigDecimal;
+
+public class ItemEditServlet extends HttpServlet {
+    private final ItemService service = new ItemService();
+
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        try {
+            int id = Integer.parseInt(req.getParameter("id"));
+            Item it = service.find(id);
+            if (it == null) { resp.sendRedirect(req.getContextPath()+"/items?err=notfound"); return; }
+            req.setAttribute("mode", "edit");
+            req.setAttribute("item", it);
+            req.getRequestDispatcher("/views/item_form.jsp").forward(req, resp);
+        } catch (Exception e) { resp.sendRedirect(req.getContextPath()+"/items?err=bad_id"); }
+    }
+
+    @Override protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        Item it = new Item();
+        try { it.setId(Integer.parseInt(req.getParameter("id"))); } catch (Exception ignored) {}
+        it.setName(req.getParameter("name"));
+        it.setStatus(req.getParameter("status"));
+        try { it.setUnitPrice(new BigDecimal(req.getParameter("unit_price"))); }
+        catch (Exception e) { it.setUnitPrice(null); }
+
+        String updatedBy = String.valueOf(req.getSession().getAttribute("username"));
+        try {
+            service.update(it, updatedBy);
+            resp.sendRedirect(req.getContextPath()+"/items?msg=updated");
+        } catch (Exception ex) {
+            req.setAttribute("mode", "edit");
+            req.setAttribute("error", ex.getMessage());
+            req.setAttribute("item", it);
+            req.getRequestDispatcher("/views/item_form.jsp").forward(req, resp);
+        }
+    }
+}

--- a/src/main/java/lk/icbt/pahana/web/ItemListServlet.java
+++ b/src/main/java/lk/icbt/pahana/web/ItemListServlet.java
@@ -1,0 +1,19 @@
+package lk.icbt.pahana.web;
+
+import lk.icbt.pahana.service.ItemService;
+import javax.servlet.http.*;
+import javax.servlet.ServletException;
+import java.io.IOException;
+
+public class ItemListServlet extends HttpServlet {
+    private final ItemService service = new ItemService();
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        String q = req.getParameter("q");
+        try {
+            req.setAttribute("items", service.list(q));
+            req.setAttribute("q", q == null ? "" : q);
+            req.getRequestDispatcher("/views/items.jsp").forward(req, resp);
+        } catch (Exception e) { throw new ServletException(e); }
+    }
+}

--- a/src/main/java/lk/icbt/pahana/web/ItemNewServlet.java
+++ b/src/main/java/lk/icbt/pahana/web/ItemNewServlet.java
@@ -1,0 +1,13 @@
+package lk.icbt.pahana.web;
+
+import javax.servlet.http.*;
+import javax.servlet.ServletException;
+import java.io.IOException;
+
+public class ItemNewServlet extends HttpServlet {
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        req.setAttribute("mode", "create");
+        req.getRequestDispatcher("/views/item_form.jsp").forward(req, resp);
+    }
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -97,6 +97,62 @@
         <url-pattern>/auth/logout</url-pattern>
     </servlet-mapping>
 
+    <!-- Items -->
+    <servlet>
+        <servlet-name>ItemListServlet</servlet-name>
+        <servlet-class>lk.icbt.pahana.web.ItemListServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>ItemListServlet</servlet-name>
+        <url-pattern>/items</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>ItemNewServlet</servlet-name>
+        <servlet-class>lk.icbt.pahana.web.ItemNewServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>ItemNewServlet</servlet-name>
+        <url-pattern>/items/new</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>ItemCreateServlet</servlet-name>
+        <servlet-class>lk.icbt.pahana.web.ItemCreateServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>ItemCreateServlet</servlet-name>
+        <url-pattern>/items/create</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>ItemEditServlet</servlet-name>
+        <servlet-class>lk.icbt.pahana.web.ItemEditServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>ItemEditServlet</servlet-name>
+        <url-pattern>/items/edit</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>ItemDeleteServlet</servlet-name>
+        <servlet-class>lk.icbt.pahana.web.ItemDeleteServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>ItemDeleteServlet</servlet-name>
+        <url-pattern>/items/delete</url-pattern>
+    </servlet-mapping>
+
+    <!-- Protect items routes -->
+    <filter-mapping>
+        <filter-name>AuthFilter</filter-name>
+        <url-pattern>/items</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>AuthFilter</filter-name>
+        <url-pattern>/items/*</url-pattern>
+    </filter-mapping>
+
 
     <session-config>
         <session-timeout>30</session-timeout>

--- a/src/main/webapp/views/item_form.jsp
+++ b/src/main/webapp/views/item_form.jsp
@@ -1,0 +1,80 @@
+<%@ page import="lk.icbt.pahana.model.Item" %>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+
+<%!
+    private static String esc(Object o){
+        if (o == null) return "";
+        String s = String.valueOf(o);
+        return s.replace("&","&amp;").replace("<","&lt;")
+                .replace(">","&gt;").replace("\"","&quot;");
+    }
+%>
+
+<%
+    Object username = session.getAttribute("username");
+    if (username == null) { response.sendRedirect(request.getContextPath()+"/views/login.jsp"); return; }
+    String mode = (String) request.getAttribute("mode");     // create | edit
+    Item it = (Item) request.getAttribute("item");
+    boolean isEdit = "edit".equalsIgnoreCase(mode);
+    String error = (String) request.getAttribute("error");
+%>
+
+<!doctype html>
+<html>
+<head>
+    <title><%= isEdit ? "Edit" : "New" %> Item</title>
+    <style>
+        body{font-family:Arial,Helvetica,sans-serif;margin:24px;}
+        .card{max-width:640px;padding:20px;border:1px solid #ddd;border-radius:10px;}
+        .row{display:flex;gap:12px;align-items:center;margin-bottom:10px;}
+        .row label{width:140px;font-weight:bold;}
+        .row input,.row select{flex:1;padding:8px;border:1px solid #ccc;border-radius:6px;}
+        .actions{display:flex;gap:10px;margin-top:16px;}
+        .btn{padding:8px 14px;border:1px solid #1b5e20;background:#2e7d32;color:#fff;border-radius:8px;cursor:pointer;}
+        .btn.secondary{border-color:#555;background:#777;}
+    </style>
+</head>
+<body>
+<h2><%= isEdit ? "Edit" : "New" %> Item</h2>
+<p><a href="<%=request.getContextPath()%>/items">&larr; Back to Items</a></p>
+
+<div class="card">
+    <% if (error != null && !error.isBlank()) { %>
+    <div style="background:#ffecec;border:1px solid #f5b5b5;color:#a40000;padding:8px;border-radius:8px;margin-bottom:12px;">
+        <%= esc(error) %>
+    </div>
+    <% } %>
+
+    <form method="post" action="<%= isEdit ? (request.getContextPath()+"/items/edit")
+                                         : (request.getContextPath()+"/items/create") %>">
+        <% if (isEdit) { %>
+        <input type="hidden" name="id" value="<%= it!=null?it.getId():0 %>">
+        <% } %>
+
+        <div class="row">
+            <label for="name">Name</label>
+            <input id="name" name="name" value="<%= it!=null?esc(it.getName()):"" %>" required minlength="2">
+        </div>
+
+        <div class="row">
+            <label for="unit_price">Unit Price</label>
+            <input id="unit_price" name="unit_price" type="number" step="0.01" min="0"
+                   value="<%= it!=null && it.getUnitPrice()!=null ? it.getUnitPrice().setScale(2) : "" %>" required>
+        </div>
+
+        <div class="row">
+            <label for="status">Status</label>
+            <select id="status" name="status" required>
+                <option value="ACTIVE"   <%= it!=null && "ACTIVE".equals(it.getStatus())?"selected":"" %>>ACTIVE</option>
+                <option value="INACTIVE" <%= it!=null && "INACTIVE".equals(it.getStatus())?"selected":"" %>>INACTIVE</option>
+            </select>
+        </div>
+
+        <div class="actions">
+            <button class="btn" type="submit"><%= isEdit ? "Save Changes" : "Create Item" %></button>
+            <a class="btn secondary" href="<%=request.getContextPath()%>/items" style="text-decoration:none;display:inline-block;">Cancel</a>
+        </div>
+    </form>
+</div>
+</body>
+</html>

--- a/src/main/webapp/views/items.jsp
+++ b/src/main/webapp/views/items.jsp
@@ -1,0 +1,66 @@
+<%@ page import="java.util.*, java.math.BigDecimal, lk.icbt.pahana.model.Item" %>
+<%@ page contentType="text/html;charset=UTF-8" %>
+<%
+    Object username = session.getAttribute("username");
+    if (username == null) { response.sendRedirect(request.getContextPath()+"/views/login.jsp"); return; }
+    @SuppressWarnings("unchecked")
+    List<Item> items = (List<Item>) request.getAttribute("items");
+    String q = (String) (request.getAttribute("q")==null ? "" : request.getAttribute("q"));
+%>
+<!doctype html>
+<html>
+<head><title>Items</title>
+    <style>
+        body{font-family:Arial,Helvetica,sans-serif;margin:24px;}
+        table{border-collapse:collapse;width:100%;}
+        th,td{border:1px solid #ddd;padding:8px;text-align:left;}
+        th{background:#f3f3f3;}
+        .toolbar{display:flex;gap:10px;align-items:center;margin-bottom:12px;}
+        .pill{padding:6px 10px;border:1px solid #2e7d32;background:#2e7d32;color:#fff;border-radius:8px;text-decoration:none;}
+        .danger{border-color:#8b0000;background:#b22222;}
+    </style>
+</head>
+<body>
+<h2>Items</h2>
+
+<div class="toolbar">
+    <form method="get" action="<%=request.getContextPath()%>/items">
+        <input name="q" value="<%=q%>" placeholder="Search name"/>
+        <button type="submit">Search</button>
+    </form>
+    <a class="pill" href="<%=request.getContextPath()%>/items/new">+ New Item</a>
+    <a href="<%=request.getContextPath()%>/views/dashboard.jsp">Back to Dashboard</a>
+</div>
+
+<p style="color:green;"><%= request.getParameter("msg")==null?"":request.getParameter("msg") %></p>
+<p style="color:red;"><%= request.getParameter("err")==null?"":request.getParameter("err") %></p>
+
+<table>
+    <tr>
+        <th>ID</th><th>Name</th><th>Unit Price</th><th>Status</th><th>Actions</th>
+    </tr>
+    <%
+        if (items != null) {
+            for (Item it : items) {
+    %>
+    <tr>
+        <td><%= it.getId() %></td>
+        <td><%= it.getName() %></td>
+        <td><%= it.getUnitPrice()==null?"":it.getUnitPrice().setScale(2) %></td>
+        <td><%= it.getStatus() %></td>
+        <td>
+            <a href="<%=request.getContextPath()%>/items/edit?id=<%= it.getId() %>">Edit</a>
+            <form method="post" action="<%=request.getContextPath()%>/items/delete" style="display:inline"
+                  onsubmit="return confirm('Delete item <%=it.getName()%>?');">
+                <input type="hidden" name="id" value="<%= it.getId() %>">
+                <button class="pill danger" type="submit">Delete</button>
+            </form>
+        </td>
+    </tr>
+    <%
+            }
+        }
+    %>
+</table>
+</body>
+</html>


### PR DESCRIPTION
# Items: implement Item CRUD (Model/DAO/Service/Servlets/JSP) with validation & auth

## Summary

Adds full **Item management** to the Pahana web app using pure Servlets/JSP and a 3-tier OOP design (Model → DAO → Service → Web). Includes create, list/search, edit, delete, server-side validation, and route protection via `AuthFilter`. 

## What’s Included

* **DB**
  * `items` table with audit columns (`created_/updated_`).

* **Model**
  * `lk.icbt.pahana.model.Item`

* **DAO**
  * `lk.icbt.pahana.dao.ItemDAO` (prepared statements, mapping).

* **Service**
  * `lk.icbt.pahana.service.ItemService` (validation: name ≥ 2, price ≥ 0, status ∈ {ACTIVE, INACTIVE}).

* **Servlets**
  * `ItemListServlet`  → `GET /items`
  * `ItemNewServlet`   → `GET /items/new`
  * `ItemCreateServlet`→ `POST /items/create`
  * `ItemEditServlet`  → `GET /items/edit?id=…`, `POST /items/edit`
  * `ItemDeleteServlet`→ `POST /items/delete`

* **JSPs**
  * `views/items.jsp` (list + search + actions)
  * `views/item_form.jsp` (create/edit form; HTML escape helper)

* **Wiring**
  * `web.xml` mappings for all routes
  * `AuthFilter` extended to protect `/items` and `/items/*`
  * Dashboard link to **Manage Items**

## Database Migration

```sql
CREATE TABLE IF NOT EXISTS items (
  id INT AUTO_INCREMENT PRIMARY KEY,
  name VARCHAR(120) NOT NULL,
  unit_price DECIMAL(10,2) NOT NULL,
  status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',   -- ACTIVE | INACTIVE
  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
  created_by VARCHAR(50),
  updated_at TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
  updated_by VARCHAR(50)
);
